### PR TITLE
fix queueing

### DIFF
--- a/timers.js
+++ b/timers.js
@@ -18,7 +18,7 @@ var lastId = 0;
 var insert = function(time, fn, repeat, id) {
   var i = 0;
 
-  while (i < queue.length && queue[i].now <= time)
+  while (i < queue.length && queue[i].time <= now)
     ++i;
 
   if (id == null)


### PR DESCRIPTION
`queue[i].now` is never set. As a result, we never enter the while loop, and always insert at the front of our queue. This is presumably not the intended behavior, and can result in some unexpected behavior.

I assume that checking `time <= now` was the originally intended behavior.
